### PR TITLE
Carousel Caption Overlap Fix

### DIFF
--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -1,0 +1,7 @@
+#c-theme .poptrox-popup {
+    padding-bottom: 0;
+}
+
+#c-theme .caption {
+    background-color: rgba(0,0,0,0.4);
+}

--- a/index.html
+++ b/index.html
@@ -13,8 +13,9 @@
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
 		<!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->
+        <link rel="stylesheet" href="assets/css/overrides.css">
 	</head>
-	<body>
+	<body id="c-theme">
 
 		<!-- Header -->
 			<header id="header">


### PR DESCRIPTION
This change was purely css-based. 

In CSS, selectors can be mixed and matched to create more specific selections. You can compute the "specificity" of a selector with the following rules:

tagName selector : specificity = 1
className selector : specificity  = 10
ID selector - specificity = Infinity

So for example,

```css
.foobar { // specificity of 1
    color: red;
}

.foobar span { // specificity of 11 - .foobar = 10, span = 1
    color: blue;
}

// text will be blue up to this point

#someId .foobar { // infinity + 10
    color: yellow;
}

// text will be red

#someId .foobar span { // infinity + 10 + 1
    color: green;
}

// text will be green
```

I placed an id of `c-theme` and namespaced the classes required to make these updates with that ID to achieve desired results.